### PR TITLE
Remove namespace from tests

### DIFF
--- a/test/bundle_inspector_test.rb
+++ b/test/bundle_inspector_test.rb
@@ -1,67 +1,63 @@
 require "test_helper"
 
-module Gemdiff
-  class BundleInspectorTest < MiniTest::Spec
-    describe "#list" do
-      it "returns outdated gems for old bundler" do
-        inspector = BundleInspector.new
-        inspector.stubs bundle_outdated_strict: fake_outdated_old
-        inspector.list.tap do |list|
-          assert_equal 2, list.size
-          assert_equal "aws-sdk", list[0].name
-          assert_equal "1.34.1", list[0].old_version
-          assert_equal "1.35.0", list[0].new_version
-          assert_equal "haml", list[1].name
-          assert_equal "4.0.4", list[1].old_version
-          assert_equal "4.0.5", list[1].new_version
-        end
-      end
+class BundleInspectorTest < MiniTest::Spec
+  let(:inspector) { Gemdiff::BundleInspector.new }
 
-      it "returns outdated gems" do
-        inspector = BundleInspector.new
-        inspector.stubs bundle_outdated_strict: fake_outdated
-        inspector.list.tap do |list|
-          assert_equal 3, list.size
-          assert_equal "paperclip", list[0].name
-          assert_equal "4.2.2", list[0].old_version
-          assert_equal "4.3.0", list[0].new_version
-          assert_equal "rails", list[1].name
-          assert_equal "4.2.1", list[1].old_version
-          assert_equal "4.2.2", list[1].new_version
-          assert_equal "web-console", list[2].name
-          assert_equal "2.1.2", list[2].old_version
-          assert_equal "2.1.3", list[2].new_version
-        end
-      end
-
-      it "returns empty list when bundle is up to date" do
-        inspector = BundleInspector.new
-        inspector.stubs bundle_outdated_strict: fake_up_to_date
-        assert_empty inspector.list
+  describe "#list" do
+    it "returns outdated gems for old bundler" do
+      inspector.stubs bundle_outdated_strict: fake_outdated_old
+      inspector.list.tap do |list|
+        assert_equal 2, list.size
+        assert_equal "aws-sdk", list[0].name
+        assert_equal "1.34.1", list[0].old_version
+        assert_equal "1.35.0", list[0].new_version
+        assert_equal "haml", list[1].name
+        assert_equal "4.0.4", list[1].old_version
+        assert_equal "4.0.5", list[1].new_version
       end
     end
 
-    describe "#get" do
-      it "returns single outdated gem" do
-        inspector = BundleInspector.new
-        inspector.stubs bundle_outdated_strict: fake_outdated_old
-        inspector.get("haml").tap do |gem|
-          assert_equal "haml", gem.name
-          assert_equal "4.0.4", gem.old_version
-          assert_equal "4.0.5", gem.new_version
-        end
-      end
-
-      it "returns nil when gem is not outdated" do
-        inspector = BundleInspector.new
-        inspector.stubs bundle_outdated_strict: fake_up_to_date
-        assert_nil inspector.get("notfound")
+    it "returns outdated gems" do
+      inspector.stubs bundle_outdated_strict: fake_outdated
+      inspector.list.tap do |list|
+        assert_equal 3, list.size
+        assert_equal "paperclip", list[0].name
+        assert_equal "4.2.2", list[0].old_version
+        assert_equal "4.3.0", list[0].new_version
+        assert_equal "rails", list[1].name
+        assert_equal "4.2.1", list[1].old_version
+        assert_equal "4.2.2", list[1].new_version
+        assert_equal "web-console", list[2].name
+        assert_equal "2.1.2", list[2].old_version
+        assert_equal "2.1.3", list[2].new_version
       end
     end
 
-    private
+    it "returns empty list when bundle is up to date" do
+      inspector.stubs bundle_outdated_strict: fake_up_to_date
+      assert_empty inspector.list
+    end
+  end
 
-    def fake_outdated_old
+  describe "#get" do
+    it "returns single outdated gem" do
+      inspector.stubs bundle_outdated_strict: fake_outdated_old
+      inspector.get("haml").tap do |gem|
+        assert_equal "haml", gem.name
+        assert_equal "4.0.4", gem.old_version
+        assert_equal "4.0.5", gem.new_version
+      end
+    end
+
+    it "returns nil when gem is not outdated" do
+      inspector.stubs bundle_outdated_strict: fake_up_to_date
+      assert_nil inspector.get("notfound")
+    end
+  end
+
+  private
+
+  def fake_outdated_old
 <<OUT
 Updating git://github.com/neighborland/active-something.git
 Fetching gem metadata from https://rubygems.org/.......
@@ -73,19 +69,19 @@ Outdated gems included in the bundle:
   * aws-sdk (1.35.0 > 1.34.1)
   * haml (4.0.5 > 4.0.4)
 OUT
-    end
+  end
 
-    # bundler output changed around version 1.10
-    def fake_outdated
+  # bundler output changed around version 1.10
+  def fake_outdated
 <<OUT
 Outdated gems included in the bundle:
   * paperclip (newest 4.3.0, installed 4.2.2) in group "default"
   * rails (newest 4.2.2, installed 4.2.1, requested ~> 4.2.1) in group "default"
   * web-console (newest 2.1.3, installed 2.1.2) in groups "development, test"
 OUT
-    end
+  end
 
-    def fake_up_to_date
+  def fake_up_to_date
 <<OUT
 Fetching gem metadata from https://rubygems.org/.........
 Fetching additional metadata from https://rubygems.org/..
@@ -93,6 +89,5 @@ Resolving dependencies...
 
 Your bundle is up to date!
 OUT
-    end
   end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,181 +1,177 @@
 require "test_helper"
 
-module Gemdiff
-  class CLITest < MiniTest::Spec
+class CLITest < MiniTest::Spec
+  let(:cli) { Gemdiff::CLI.new }
+
+  describe "#find" do
+    it "finds" do
+      mock_gem "haml"
+      cli.expects(:puts).with("http://github.com/haml/haml")
+      cli.find "haml"
+    end
+
+    it "does not find" do
+      mock_missing_gem
+      cli.expects(:puts).with("Could not find github repository for notfound.")
+      cli.find "notfound"
+    end
+  end
+
+  describe "#open" do
+    it "opens repo" do
+      outdated_gem = mock_gem("haml")
+      cli.expects(:puts).with("http://github.com/haml/haml")
+      outdated_gem.expects :open
+      cli.open "haml"
+    end
+  end
+
+  describe "#releases" do
+    it "opens releases page" do
+      outdated_gem = mock_gem("haml")
+      cli.expects(:puts).with("http://github.com/haml/haml")
+      outdated_gem.expects :releases
+      cli.releases "haml"
+    end
+  end
+
+  describe "#master" do
+    it "opens commits page" do
+      outdated_gem = mock_gem("haml")
+      cli.expects(:puts).with("http://github.com/haml/haml")
+      outdated_gem.expects :master
+      cli.master "haml"
+    end
+  end
+
+  describe "#compare" do
+    it "opens compare view using bundle" do
+      outdated_gem = mock_gem("haml")
+      cli.expects(:puts).with("http://github.com/haml/haml")
+      outdated_gem.expects(:set_versions).with(nil, nil)
+      outdated_gem.expects(:missing_versions?).returns(true)
+      cli.expects(:puts).with(Gemdiff::CLI::CHECKING_FOR_OUTDATED)
+      outdated_gem.expects(:load_bundle_versions).returns(true)
+      outdated_gem.expects(:compare_message).returns("compare message")
+      cli.expects(:puts).with("compare message")
+      outdated_gem.expects :compare
+      cli.compare "haml"
+    end
+
+    it "opens compare view with versions" do
+      outdated_gem = mock_gem("haml")
+      cli.expects(:puts).with("http://github.com/haml/haml")
+      outdated_gem.expects(:set_versions).with("4.0.4", "4.0.5")
+      outdated_gem.expects(:missing_versions?).returns(false)
+      outdated_gem.expects(:compare_message).returns("compare message")
+      cli.expects(:puts).with("compare message")
+      outdated_gem.expects :compare
+      cli.compare "haml", "4.0.4", "4.0.5"
+    end
+
+    it "returns when the gem is not found" do
+      mock_missing_gem
+      cli.expects(:puts).with("Could not find github repository for notfound.")
+      cli.compare "notfound"
+    end
+  end
+
+  describe "#outdated" do
+    it "does nothing when nothing to update" do
+      mock_inspector = mock do
+        stubs list: []
+        stubs outdated: ""
+      end
+      Gemdiff::BundleInspector.stubs new: mock_inspector
+      cli.expects(:puts).with(Gemdiff::CLI::CHECKING_FOR_OUTDATED)
+      cli.expects(:puts).with("")
+      cli.outdated
+    end
+
+    it "compares outdated gems with responses of y" do
+      outdated_gem = Gemdiff::OutdatedGem.new("haml", "4.0.4", "4.0.5")
+      mock_inspector = mock do
+        stubs list: [outdated_gem]
+        stubs outdated: "outdated"
+      end
+      Gemdiff::BundleInspector.stubs new: mock_inspector
+      cli.stubs ask: "y"
+      cli.expects(:puts).with(Gemdiff::CLI::CHECKING_FOR_OUTDATED)
+      cli.expects(:puts).with("outdated")
+      cli.expects(:puts).with("haml: 4.0.5 > 4.0.4")
+      outdated_gem.expects :compare
+      cli.outdated
+    end
+
+    it "skips outdated gems without responses of y" do
+      outdated_gem = Gemdiff::OutdatedGem.new("haml", "4.0.4", "4.0.5")
+      mock_inspector = mock do
+        stubs list: [outdated_gem]
+        stubs outdated: "outdated"
+      end
+      Gemdiff::BundleInspector.stubs new: mock_inspector
+      cli.stubs ask: ""
+      cli.expects(:puts).with(Gemdiff::CLI::CHECKING_FOR_OUTDATED)
+      cli.expects(:puts).with("outdated")
+      cli.expects(:puts).with("haml: 4.0.5 > 4.0.4")
+      outdated_gem.expects(:compare).never
+      cli.outdated
+    end
+  end
+
+  describe "#update" do
     before do
-      @cli = CLI.new
+      @mock_gem = mock do
+        stubs clean?: true
+        stubs diff: "le diff"
+        stubs show: "le show"
+      end
+      Gemdiff::GemUpdater.stubs new: @mock_gem
     end
 
-    describe "#find" do
-      it "finds" do
-        mock_gem "haml"
-        @cli.expects(:puts).with("http://github.com/haml/haml")
-        @cli.find "haml"
-      end
-
-      it "does not find" do
-        mock_missing_gem
-        @cli.expects(:puts).with("Could not find github repository for notfound.")
-        @cli.find "notfound"
-      end
+    it "updates the gem and returns with no response" do
+      cli.stubs ask: ""
+      cli.expects(:puts).with("Updating haml...")
+      @mock_gem.expects :update
+      cli.expects(:puts).with("le diff")
+      cli.update "haml"
     end
 
-    describe "#open" do
-      it "opens repo" do
-        outdated_gem = mock_gem("haml")
-        @cli.expects(:puts).with("http://github.com/haml/haml")
-        outdated_gem.expects :open
-        @cli.open "haml"
-      end
+    it "updates the gem and commits with responses of c" do
+      cli.stubs ask: "c"
+      cli.expects(:puts).with("Updating haml...")
+      @mock_gem.expects :update
+      cli.expects(:puts).with("le diff")
+      @mock_gem.expects :commit
+      cli.expects(:puts).with("\nle show")
+      cli.update "haml"
     end
 
-    describe "#releases" do
-      it "opens releases page" do
-        outdated_gem = mock_gem("haml")
-        @cli.expects(:puts).with("http://github.com/haml/haml")
-        outdated_gem.expects :releases
-        @cli.releases "haml"
-      end
+    it "updates the gem and resets with responses of r" do
+      cli.stubs ask: "r"
+      cli.expects(:puts).with("Updating haml...")
+      @mock_gem.expects :update
+      cli.expects(:puts).with("le diff")
+      @mock_gem.expects(:reset).returns("le reset")
+      cli.expects(:puts).with("le reset")
+      cli.update "haml"
     end
+  end
 
-    describe "#master" do
-      it "opens commits page" do
-        outdated_gem = mock_gem("haml")
-        @cli.expects(:puts).with("http://github.com/haml/haml")
-        outdated_gem.expects :master
-        @cli.master "haml"
-      end
+  private
+
+  def mock_gem(name)
+    outdated_gem = mock do
+      stubs repo?: true
+      stubs repo: "http://github.com/#{name}/#{name}"
     end
+    Gemdiff::OutdatedGem.stubs new: outdated_gem
+    outdated_gem
+  end
 
-    describe "#compare" do
-      it "opens compare view using bundle" do
-        outdated_gem = mock_gem("haml")
-        @cli.expects(:puts).with("http://github.com/haml/haml")
-        outdated_gem.expects(:set_versions).with(nil, nil)
-        outdated_gem.expects(:missing_versions?).returns(true)
-        @cli.expects(:puts).with(CLI::CHECKING_FOR_OUTDATED)
-        outdated_gem.expects(:load_bundle_versions).returns(true)
-        outdated_gem.expects(:compare_message).returns("compare message")
-        @cli.expects(:puts).with("compare message")
-        outdated_gem.expects :compare
-        @cli.compare "haml"
-      end
-
-      it "opens compare view with versions" do
-        outdated_gem = mock_gem("haml")
-        @cli.expects(:puts).with("http://github.com/haml/haml")
-        outdated_gem.expects(:set_versions).with("4.0.4", "4.0.5")
-        outdated_gem.expects(:missing_versions?).returns(false)
-        outdated_gem.expects(:compare_message).returns("compare message")
-        @cli.expects(:puts).with("compare message")
-        outdated_gem.expects :compare
-        @cli.compare "haml", "4.0.4", "4.0.5"
-      end
-
-      it "returns when the gem is not found" do
-        mock_missing_gem
-        @cli.expects(:puts).with("Could not find github repository for notfound.")
-        @cli.compare "notfound"
-      end
-    end
-
-    describe "#outdated" do
-      it "does nothing when nothing to update" do
-        mock_inspector = mock do
-          stubs list: []
-          stubs outdated: ""
-        end
-        BundleInspector.stubs new: mock_inspector
-        @cli.expects(:puts).with(CLI::CHECKING_FOR_OUTDATED)
-        @cli.expects(:puts).with("")
-        @cli.outdated
-      end
-
-      it "compares outdated gems with responses of y" do
-        outdated_gem = OutdatedGem.new("haml", "4.0.4", "4.0.5")
-        mock_inspector = mock do
-          stubs list: [outdated_gem]
-          stubs outdated: "outdated"
-        end
-        BundleInspector.stubs new: mock_inspector
-        @cli.stubs ask: "y"
-        @cli.expects(:puts).with(CLI::CHECKING_FOR_OUTDATED)
-        @cli.expects(:puts).with("outdated")
-        @cli.expects(:puts).with("haml: 4.0.5 > 4.0.4")
-        outdated_gem.expects :compare
-        @cli.outdated
-      end
-
-      it "skips outdated gems without responses of y" do
-        outdated_gem = OutdatedGem.new("haml", "4.0.4", "4.0.5")
-        mock_inspector = mock do
-          stubs list: [outdated_gem]
-          stubs outdated: "outdated"
-        end
-        BundleInspector.stubs new: mock_inspector
-        @cli.stubs ask: ""
-        @cli.expects(:puts).with(CLI::CHECKING_FOR_OUTDATED)
-        @cli.expects(:puts).with("outdated")
-        @cli.expects(:puts).with("haml: 4.0.5 > 4.0.4")
-        outdated_gem.expects(:compare).never
-        @cli.outdated
-      end
-    end
-
-    describe "#update" do
-      before do
-        @mock_gem = mock do
-          stubs clean?: true
-          stubs diff: "le diff"
-          stubs show: "le show"
-        end
-        GemUpdater.stubs new: @mock_gem
-      end
-
-      it "updates the gem and returns with no response" do
-        @cli.stubs ask: ""
-        @cli.expects(:puts).with("Updating haml...")
-        @mock_gem.expects :update
-        @cli.expects(:puts).with("le diff")
-        @cli.update "haml"
-      end
-
-      it "updates the gem and commits with responses of c" do
-        @cli.stubs ask: "c"
-        @cli.expects(:puts).with("Updating haml...")
-        @mock_gem.expects :update
-        @cli.expects(:puts).with("le diff")
-        @mock_gem.expects :commit
-        @cli.expects(:puts).with("\nle show")
-        @cli.update "haml"
-      end
-
-      it "updates the gem and resets with responses of r" do
-        @cli.stubs ask: "r"
-        @cli.expects(:puts).with("Updating haml...")
-        @mock_gem.expects :update
-        @cli.expects(:puts).with("le diff")
-        @mock_gem.expects(:reset).returns("le reset")
-        @cli.expects(:puts).with("le reset")
-        @cli.update "haml"
-      end
-    end
-
-    private
-
-    def mock_gem(name)
-      outdated_gem = mock do
-        stubs repo?: true
-        stubs repo: "http://github.com/#{name}/#{name}"
-      end
-      OutdatedGem.stubs new: outdated_gem
-      outdated_gem
-    end
-
-    def mock_missing_gem
-      outdated_gem = mock { stubs repo?: false }
-      OutdatedGem.stubs new: outdated_gem
-      outdated_gem
-    end
+  def mock_missing_gem
+    outdated_gem = mock { stubs repo?: false }
+    Gemdiff::OutdatedGem.stubs new: outdated_gem
+    outdated_gem
   end
 end

--- a/test/gem_updater_test.rb
+++ b/test/gem_updater_test.rb
@@ -1,75 +1,73 @@
 require "test_helper"
 
-module Gemdiff
-  class GemUpdaterTest < MiniTest::Spec
-    describe "#update" do
-      it "updates the gem" do
-        updater = GemUpdater.new("x")
-        updater.expects :bundle_update
-        updater.update
-      end
+class GemUpdaterTest < MiniTest::Spec
+  describe "#update" do
+    it "updates the gem" do
+      updater = Gemdiff::GemUpdater.new("x")
+      updater.expects :bundle_update
+      updater.update
+    end
+  end
+
+  describe "#commit" do
+    it "adds a git commit for a gem update" do
+      updater = Gemdiff::GemUpdater.new("aws-sdk")
+      updater.stubs git_changed_line: "+    aws-sdk (1.35.0)"
+      updater.expects(:git_add_and_commit_lockfile).with("1.35.0")
+      assert updater.commit
     end
 
-    describe "#commit" do
-      it "adds a git commit for a gem update" do
-        updater = GemUpdater.new("aws-sdk")
-        updater.stubs git_changed_line: "+    aws-sdk (1.35.0)"
-        updater.expects(:git_add_and_commit_lockfile).with("1.35.0")
-        assert updater.commit
-      end
-
-      it "adds a git commit for an update from a specific ref" do
-        updater = GemUpdater.new("sass-rails")
-        updater.stubs git_changed_line: "+    sass-rails (4.0.3)\n+  sass-rails"
-        updater.expects(:git_add_and_commit_lockfile).with("4.0.3")
-        assert updater.commit
-      end
-
-      it "adds a git commit for an update with dependencies" do
-        updater = GemUpdater.new("activejob")
-        updater.stubs git_changed_line: \
-          "+      activejob (= 4.2.3)\n+    activejob (4.2.3)\n+      activejob (= 4.2.3)"
-        updater.expects(:git_add_and_commit_lockfile).with("4.2.3")
-        assert updater.commit
-      end
+    it "adds a git commit for an update from a specific ref" do
+      updater = Gemdiff::GemUpdater.new("sass-rails")
+      updater.stubs git_changed_line: "+    sass-rails (4.0.3)\n+  sass-rails"
+      updater.expects(:git_add_and_commit_lockfile).with("4.0.3")
+      assert updater.commit
     end
 
-    describe "#reset" do
-      it "resets Gemfile.lock" do
-        updater = GemUpdater.new("x")
-        updater.expects :git_reset
-        updater.reset
-      end
+    it "adds a git commit for an update with dependencies" do
+      updater = Gemdiff::GemUpdater.new("activejob")
+      updater.stubs git_changed_line: \
+        "+      activejob (= 4.2.3)\n+    activejob (4.2.3)\n+      activejob (= 4.2.3)"
+      updater.expects(:git_add_and_commit_lockfile).with("4.2.3")
+      assert updater.commit
+    end
+  end
+
+  describe "#reset" do
+    it "resets Gemfile.lock" do
+      updater = Gemdiff::GemUpdater.new("x")
+      updater.expects :git_reset
+      updater.reset
+    end
+  end
+
+  describe "#diff" do
+    it "returns git diff" do
+      updater = Gemdiff::GemUpdater.new("x")
+      updater.expects :git_diff
+      updater.diff
+    end
+  end
+
+  describe "#show" do
+    it "returns git show" do
+      updater = Gemdiff::GemUpdater.new("x")
+      updater.expects :git_show
+      updater.show
+    end
+  end
+
+  describe "#clean?" do
+    it "returns true for empty diff" do
+      updater = Gemdiff::GemUpdater.new("x")
+      updater.stubs git_diff: ""
+      assert updater.clean?
     end
 
-    describe "#diff" do
-      it "returns git diff" do
-        updater = GemUpdater.new("x")
-        updater.expects :git_diff
-        updater.diff
-      end
-    end
-
-    describe "#show" do
-      it "returns git show" do
-        updater = GemUpdater.new("x")
-        updater.expects :git_show
-        updater.show
-      end
-    end
-
-    describe "#clean?" do
-      it "returns true for empty diff" do
-        updater = GemUpdater.new("x")
-        updater.stubs git_diff: ""
-        assert updater.clean?
-      end
-
-      it "returns false for non-empty diff" do
-        updater = GemUpdater.new("x")
-        updater.stubs git_diff: "something"
-        refute updater.clean?
-      end
+    it "returns false for non-empty diff" do
+      updater = Gemdiff::GemUpdater.new("x")
+      updater.stubs git_diff: "something"
+      refute updater.clean?
     end
   end
 end

--- a/test/outdated_gem_test.rb
+++ b/test/outdated_gem_test.rb
@@ -1,150 +1,148 @@
 require "test_helper"
 
-module Gemdiff
-  class OutdatedGemTest < MiniTest::Spec
-    describe "#missing_versions?" do
-      it "returns true" do
-        assert OutdatedGem.new("x").missing_versions?
-      end
-
-      it "returns false" do
-        refute OutdatedGem.new("x", "1", "2").missing_versions?
-      end
+class OutdatedGemTest < MiniTest::Spec
+  describe "#missing_versions?" do
+    it "returns true" do
+      assert Gemdiff::OutdatedGem.new("x").missing_versions?
     end
 
-    describe "#compare_url" do
-      it "returns compare url" do
-        outdated_gem = OutdatedGem.new("x", "1.0", "2.0")
-        outdated_gem.stubs repo: "http://github.com/x/x"
-        assert_equal "http://github.com/x/x/compare/v1.0...v2.0", outdated_gem.compare_url
-      end
+    it "returns false" do
+      refute Gemdiff::OutdatedGem.new("x", "1", "2").missing_versions?
+    end
+  end
 
-      it "returns compare url with no v for exceptions" do
-        outdated_gem = OutdatedGem.new("haml", "4.0.0", "4.1.0")
-        outdated_gem.stubs repo: "http://github.com/haml/haml"
-        assert_equal "http://github.com/haml/haml/compare/4.0.0...4.1.0", outdated_gem.compare_url
-      end
-
-      it "returns compare url with branch name for new version" do
-        outdated_gem = OutdatedGem.new("x", "4.0.0", "master")
-        outdated_gem.stubs repo: "http://github.com/x/x"
-        assert_equal "http://github.com/x/x/compare/v4.0.0...master", outdated_gem.compare_url
-      end
+  describe "#compare_url" do
+    it "returns compare url" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x", "1.0", "2.0")
+      outdated_gem.stubs repo: "http://github.com/x/x"
+      assert_equal "http://github.com/x/x/compare/v1.0...v2.0", outdated_gem.compare_url
     end
 
-    describe "#releases_url" do
-      it "returns releases url" do
-        outdated_gem = OutdatedGem.new("x")
-        outdated_gem.stubs repo: "http://github.com/x/x"
-        assert_equal "http://github.com/x/x/releases", outdated_gem.releases_url
-      end
+    it "returns compare url with no v for exceptions" do
+      outdated_gem = Gemdiff::OutdatedGem.new("haml", "4.0.0", "4.1.0")
+      outdated_gem.stubs repo: "http://github.com/haml/haml"
+      assert_equal "http://github.com/haml/haml/compare/4.0.0...4.1.0", outdated_gem.compare_url
     end
 
-    describe "#commits_url" do
-      it "returns commits url" do
-        outdated_gem = OutdatedGem.new("x")
-        outdated_gem.stubs repo: "http://github.com/x/x"
-        assert_equal "http://github.com/x/x/commits/master", outdated_gem.commits_url
-      end
+    it "returns compare url with branch name for new version" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x", "4.0.0", "master")
+      outdated_gem.stubs repo: "http://github.com/x/x"
+      assert_equal "http://github.com/x/x/compare/v4.0.0...master", outdated_gem.compare_url
+    end
+  end
+
+  describe "#releases_url" do
+    it "returns releases url" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x")
+      outdated_gem.stubs repo: "http://github.com/x/x"
+      assert_equal "http://github.com/x/x/releases", outdated_gem.releases_url
+    end
+  end
+
+  describe "#commits_url" do
+    it "returns commits url" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x")
+      outdated_gem.stubs repo: "http://github.com/x/x"
+      assert_equal "http://github.com/x/x/commits/master", outdated_gem.commits_url
+    end
+  end
+
+  describe "#compare_message" do
+    it "returns compare message" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x", "1", "2")
+      outdated_gem.stubs repo: "http://github.com/x/x"
+      assert_equal "x: 2 > 1", outdated_gem.compare_message
+    end
+  end
+
+  describe "#load_bundle_versions" do
+    it "returns false if not found" do
+      mock_inspector = mock { stubs :get }
+      Gemdiff::BundleInspector.stubs new: mock_inspector
+      refute Gemdiff::OutdatedGem.new("x").load_bundle_versions
     end
 
-    describe "#compare_message" do
-      it "returns compare message" do
-        outdated_gem = OutdatedGem.new("x", "1", "2")
-        outdated_gem.stubs repo: "http://github.com/x/x"
-        assert_equal "x: 2 > 1", outdated_gem.compare_message
-      end
+    it "sets versions from gem in bundle" do
+      mock_outdated_gem = Gemdiff::OutdatedGem.new("y", "1.2.3", "2.3.4")
+      mock_inspector = mock { stubs get: mock_outdated_gem }
+      Gemdiff::BundleInspector.stubs new: mock_inspector
+      outdated_gem = Gemdiff::OutdatedGem.new("y")
+      assert outdated_gem.load_bundle_versions
+      assert_equal "1.2.3", outdated_gem.old_version
+      assert_equal "2.3.4", outdated_gem.new_version
+    end
+  end
+
+  describe "#set_versions" do
+    it "sets nil versions" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x", "1", "2")
+      outdated_gem.set_versions nil, nil
+      assert_nil outdated_gem.old_version
+      assert_nil outdated_gem.new_version
     end
 
-    describe "#load_bundle_versions" do
-      it "returns false if not found" do
-        mock_inspector = mock { stubs :get }
-        BundleInspector.stubs new: mock_inspector
-        refute OutdatedGem.new("x").load_bundle_versions
-      end
-
-      it "sets versions from gem in bundle" do
-        mock_outdated_gem = OutdatedGem.new("y", "1.2.3", "2.3.4")
-        mock_inspector = mock { stubs get: mock_outdated_gem }
-        BundleInspector.stubs new: mock_inspector
-        outdated_gem = OutdatedGem.new("y")
-        assert outdated_gem.load_bundle_versions
-        assert_equal "1.2.3", outdated_gem.old_version
-        assert_equal "2.3.4", outdated_gem.new_version
-      end
+    it "sets old, new versions" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x")
+      outdated_gem.set_versions "1.2.34", "2.34.56"
+      assert_equal "1.2.34", outdated_gem.old_version
+      assert_equal "2.34.56", outdated_gem.new_version
     end
 
-    describe "#set_versions" do
-      it "sets nil versions" do
-        outdated_gem = OutdatedGem.new("x", "1", "2")
-        outdated_gem.set_versions nil, nil
-        assert_nil outdated_gem.old_version
-        assert_nil outdated_gem.new_version
-      end
-
-      it "sets old, new versions" do
-        outdated_gem = OutdatedGem.new("x")
-        outdated_gem.set_versions "1.2.34", "2.34.56"
-        assert_equal "1.2.34", outdated_gem.old_version
-        assert_equal "2.34.56", outdated_gem.new_version
-      end
-
-      it "swaps versions in the wrong order" do
-        outdated_gem = OutdatedGem.new("x")
-        outdated_gem.set_versions "2.34.56", "1.2.34"
-        assert_equal "1.2.34", outdated_gem.old_version
-        assert_equal "2.34.56", outdated_gem.new_version
-      end
-
-      it "swaps versions over 10 in the wrong order" do
-        outdated_gem = OutdatedGem.new("x")
-        outdated_gem.set_versions "1.10.0", "1.9.3"
-        assert_equal "1.9.3", outdated_gem.old_version
-        assert_equal "1.10.0", outdated_gem.new_version
-      end
-
-      it "swaps versions with master" do
-        outdated_gem = OutdatedGem.new("x")
-        outdated_gem.set_versions "master", "1.9.3"
-        assert_equal "1.9.3", outdated_gem.old_version
-        assert_equal "master", outdated_gem.new_version
-      end
+    it "swaps versions in the wrong order" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x")
+      outdated_gem.set_versions "2.34.56", "1.2.34"
+      assert_equal "1.2.34", outdated_gem.old_version
+      assert_equal "2.34.56", outdated_gem.new_version
     end
 
-    describe "#master" do
-      it "opens master commits url" do
-        outdated_gem = OutdatedGem.new("x")
-        outdated_gem.stubs repo: "http://github.com/x/x"
-        outdated_gem.expects(:open_url).with("http://github.com/x/x/commits/master")
-        outdated_gem.master
-      end
+    it "swaps versions over 10 in the wrong order" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x")
+      outdated_gem.set_versions "1.10.0", "1.9.3"
+      assert_equal "1.9.3", outdated_gem.old_version
+      assert_equal "1.10.0", outdated_gem.new_version
     end
 
-    describe "#releases" do
-      it "opens releases url" do
-        outdated_gem = OutdatedGem.new("x")
-        outdated_gem.stubs repo: "http://github.com/x/x"
-        outdated_gem.expects(:open_url).with("http://github.com/x/x/releases")
-        outdated_gem.releases
-      end
+    it "swaps versions with master" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x")
+      outdated_gem.set_versions "master", "1.9.3"
+      assert_equal "1.9.3", outdated_gem.old_version
+      assert_equal "master", outdated_gem.new_version
     end
+  end
 
-    describe "#compare" do
-      it "opens compare url" do
-        outdated_gem = OutdatedGem.new("x", "1.2.3", "2.3.4")
-        outdated_gem.stubs repo: "http://github.com/x/x"
-        outdated_gem.expects(:open_url).with("http://github.com/x/x/compare/v1.2.3...v2.3.4")
-        outdated_gem.compare
-      end
+  describe "#master" do
+    it "opens master commits url" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x")
+      outdated_gem.stubs repo: "http://github.com/x/x"
+      outdated_gem.expects(:open_url).with("http://github.com/x/x/commits/master")
+      outdated_gem.master
     end
+  end
 
-    describe "#open" do
-      it "opens repo url" do
-        outdated_gem = OutdatedGem.new("x")
-        outdated_gem.stubs repo: "http://github.com/x/x"
-        outdated_gem.expects(:open_url).with("http://github.com/x/x")
-        outdated_gem.open
-      end
+  describe "#releases" do
+    it "opens releases url" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x")
+      outdated_gem.stubs repo: "http://github.com/x/x"
+      outdated_gem.expects(:open_url).with("http://github.com/x/x/releases")
+      outdated_gem.releases
+    end
+  end
+
+  describe "#compare" do
+    it "opens compare url" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x", "1.2.3", "2.3.4")
+      outdated_gem.stubs repo: "http://github.com/x/x"
+      outdated_gem.expects(:open_url).with("http://github.com/x/x/compare/v1.2.3...v2.3.4")
+      outdated_gem.compare
+    end
+  end
+
+  describe "#open" do
+    it "opens repo url" do
+      outdated_gem = Gemdiff::OutdatedGem.new("x")
+      outdated_gem.stubs repo: "http://github.com/x/x"
+      outdated_gem.expects(:open_url).with("http://github.com/x/x")
+      outdated_gem.open
     end
   end
 end

--- a/test/repo_finder_test.rb
+++ b/test/repo_finder_test.rb
@@ -1,49 +1,48 @@
 require "test_helper"
 
-module Gemdiff
-  class RepoFinderTest < MiniTest::Spec
-    describe ".github_url" do
-      it "returns github url from local gemspec" do
-        RepoFinder.stubs find_local_gemspec: fake_gemspec("homepage: http://github.com/rails/arel")
-        RepoFinder.stubs last_shell_command_success?: true
-        assert_equal "http://github.com/rails/arel", RepoFinder.github_url("arel")
-      end
-
-      it "returns github url from remote gemspec" do
-        RepoFinder.stubs find_local_gemspec: ""
-        RepoFinder.stubs last_shell_command_success?: false
-        RepoFinder.stubs find_remote_gemspec: fake_gemspec("homepage: http://github.com/rails/arel")
-        assert_equal "http://github.com/rails/arel", RepoFinder.github_url("arel")
-      end
-
-      it "returns github url from github search" do
-        RepoFinder.stubs octokit_client: mock_octokit("haml/haml")
-        RepoFinder.stubs gemspec: fake_gemspec
-        assert_equal "https://github.com/haml/haml", RepoFinder.github_url("haml")
-      end
-
-      it "returns nil when not found" do
-        RepoFinder.stubs octokit_client: mock_octokit(nil)
-        RepoFinder.stubs gemspec: fake_gemspec
-        assert_nil RepoFinder.github_url("not_found")
-      end
-
-      it "returns exception url" do
-        assert_equal "https://github.com/rails/rails", RepoFinder.github_url("activerecord")
-      end
+class RepoFinderTest < MiniTest::Spec
+  describe ".github_url" do
+    it "returns github url from local gemspec" do
+      Gemdiff::RepoFinder.stubs find_local_gemspec: fake_gemspec("homepage: http://github.com/rails/arel")
+      Gemdiff::RepoFinder.stubs last_shell_command_success?: true
+      assert_equal "http://github.com/rails/arel", Gemdiff::RepoFinder.github_url("arel")
     end
 
-    private
-
-    def mock_octokit(full_name)
-      mock_items = if full_name.nil?
-                     mock { stubs items: [] }
-                   else
-                     mock_item = mock { stubs full_name: full_name }
-                     mock { stubs items: [mock_item] }
-                   end
-      mock { stubs search_repositories: mock_items }
+    it "returns github url from remote gemspec" do
+      Gemdiff::RepoFinder.stubs find_local_gemspec: ""
+      Gemdiff::RepoFinder.stubs last_shell_command_success?: false
+      Gemdiff::RepoFinder.stubs find_remote_gemspec: fake_gemspec("homepage: http://github.com/rails/arel")
+      assert_equal "http://github.com/rails/arel", Gemdiff::RepoFinder.github_url("arel")
     end
+
+    it "returns github url from github search" do
+      Gemdiff::RepoFinder.stubs octokit_client: mock_octokit("haml/haml")
+      Gemdiff::RepoFinder.stubs gemspec: fake_gemspec
+      assert_equal "https://github.com/haml/haml", Gemdiff::RepoFinder.github_url("haml")
+    end
+
+    it "returns nil when not found" do
+      Gemdiff::RepoFinder.stubs octokit_client: mock_octokit(nil)
+      Gemdiff::RepoFinder.stubs gemspec: fake_gemspec
+      assert_nil Gemdiff::RepoFinder.github_url("not_found")
+    end
+
+    it "returns exception url" do
+      assert_equal "https://github.com/rails/rails", Gemdiff::RepoFinder.github_url("activerecord")
+    end
+  end
+
+  private
+
+  def mock_octokit(full_name)
+    mock_items = if full_name.nil?
+                   mock { stubs items: [] }
+                 else
+                   mock_item = mock { stubs full_name: full_name }
+                   mock { stubs items: [mock_item] }
+                 end
+    mock { stubs search_repositories: mock_items }
+  end
 
 FAKE_GEMSPEC = %(
 --- !ruby/object:Gem::Specification
@@ -53,8 +52,7 @@ version: !ruby/object:Gem::Version
 description: fake
 )
 
-    def fake_gemspec(extra = "")
-      [FAKE_GEMSPEC, extra].compact.join("\n")
-    end
+  def fake_gemspec(extra = "")
+    [FAKE_GEMSPEC, extra].compact.join("\n")
   end
 end


### PR DESCRIPTION
Putting the tests in the same namespace as the gem is not a good idea.