### PR TITLE
Added option for showing compare urls

### DIFF
--- a/lib/gemdiff/cli.rb
+++ b/lib/gemdiff/cli.rb
@@ -65,9 +65,10 @@ DESC
       open_all = false
       inspector.list.each do |outdated_gem|
         puts outdated_gem.compare_message
-        response = open_all || ask("Open? (y to open, x to exit, A to open all, else skip)")
-        open_all = "A" if response == "A"
+        response = open_all || ask("Open? (y to open, x to exit, A to open all, s to show all to stdout, else skip)")
+        open_all = response if %(A s).include?(response)
         outdated_gem.compare if %w(y A).include?(response)
+        puts outdated_gem.compare_url if response == "s"
         return if response == "x"
       end
     end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -103,6 +103,22 @@ class CLITest < MiniTest::Spec
       cli.outdated
     end
 
+    it "show compare urls of outdated gems with responses of s" do
+      outdated_gem = Gemdiff::OutdatedGem.new("haml", "4.0.4", "4.0.5")
+      mock_inspector = mock do
+        stubs list: [outdated_gem]
+        stubs outdated: "outdated"
+      end
+      Gemdiff::BundleInspector.stubs new: mock_inspector
+      cli.stubs ask: "s"
+      cli.expects(:puts).with(Gemdiff::CLI::CHECKING_FOR_OUTDATED)
+      cli.expects(:puts).with("outdated")
+      cli.expects(:puts).with("haml: 4.0.5 > 4.0.4")
+      outdated_gem.expects(:compare_url).returns("https://github.com/haml/haml/compare/4.0.4...4.0.5")
+      cli.expects(:puts).with("https://github.com/haml/haml/compare/4.0.4...4.0.5")
+      cli.outdated
+    end
+
     it "skips outdated gems without responses of y" do
       outdated_gem = Gemdiff::OutdatedGem.new("haml", "4.0.4", "4.0.5")
       mock_inspector = mock do


### PR DESCRIPTION
I need to summarize to confirm gem diff urls on Gemfile.lock.  `gemdiff outdated` is very useful. but opening to all of urls couldn't confirm their urls.

I added `s` option when ask to confirm options. 

We can get following results(example):

```
haml: 4.0.5 > 4.0.4
https://github.com/haml/haml/compare/4.0.4...4.0.5
...
```
