### PR TITLE
Change default command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,18 @@ sqlite3: 1.3.12 > 1.3.11
 https://github.com/sparklemotion/sqlite3-ruby/compare/v1.3.11...v1.3.12
 ```
 
-### `gemdiff outdated`
+`list` is the default task, so `gemdiff` with no arguments is the same as `gemdiff list`.
+
+### `gemdiff each`
 
 Runs `bundle outdated --strict` in the current directory. For each outdated gem,
 you can open the compare view for that gem, skip it, or exit.
 Enter `y` to review. Enter `A` to open all compare views (beware!).
 Enter `s` to list all the compare URLs to stdout (same as the `list` command).
 
-`outdated` is the default task, so `gemdiff` with no arguments is the same as `gemdiff outdated`.
-
 ```sh
 $ cd /your/ruby/project/using/bundler
-$ gemdiff
+$ gemdiff each
 Checking for outdated gems in your bundle...
 Fetching gem metadata from https://rubygems.org/.......
 Fetching version metadata from https://rubygems.org/..

--- a/lib/gemdiff/cli.rb
+++ b/lib/gemdiff/cli.rb
@@ -5,7 +5,7 @@ module Gemdiff
     include Thor::Actions
     include Colorize
 
-    default_task :outdated
+    default_task :list
 
     CHECKING_FOR_OUTDATED = "Checking for outdated gems in your bundle..."
     NOTHING_TO_UPDATE = "Nothing to update."

--- a/lib/gemdiff/cli.rb
+++ b/lib/gemdiff/cli.rb
@@ -57,8 +57,8 @@ DESC
       outdated_gem.compare
     end
 
-    desc "outdated", "Compare each outdated gem in the bundle. You will be prompted to open each compare view."
-    def outdated
+    desc "each", "Compare each outdated gem in the bundle. You will be prompted to open each compare view."
+    def each
       puts CHECKING_FOR_OUTDATED
       inspector = BundleInspector.new
       puts inspector.outdated
@@ -67,11 +67,12 @@ DESC
         puts outdated_gem.compare_message
         response = open_all || ask("Open? (y to open, x to exit, A to open all, s to show all to stdout, else skip)")
         open_all = response if %(A s).include?(response)
-        outdated_gem.compare if %w(y A).include?(response)
+        outdated_gem.compare if %w[y A].include?(response)
         puts outdated_gem.compare_url if response == "s"
         return if response == "x"
       end
     end
+    map outdated: :each
 
     desc "list", "List compare URLs for all outdated gems in the bundle."
     def list

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -76,13 +76,13 @@ class CLITest < MiniTest::Spec
     end
   end
 
-  describe "#outdated" do
+  describe "#each" do
     it "does nothing when nothing to update" do
       mock_inspector = stub list: [], outdated: ""
       Gemdiff::BundleInspector.stubs new: mock_inspector
       cli.expects(:puts).with(Gemdiff::CLI::CHECKING_FOR_OUTDATED)
       cli.expects(:puts).with("")
-      cli.outdated
+      cli.each
     end
 
     it "compares outdated gems with responses of y" do
@@ -94,7 +94,7 @@ class CLITest < MiniTest::Spec
       cli.expects(:puts).with("outdated")
       cli.expects(:puts).with("haml: 4.0.5 > 4.0.4")
       outdated_gem.expects :compare
-      cli.outdated
+      cli.each
     end
 
     it "show compare urls of outdated gems with responses of s" do
@@ -107,7 +107,7 @@ class CLITest < MiniTest::Spec
       cli.expects(:puts).with("haml: 4.0.5 > 4.0.4")
       outdated_gem.expects(:compare_url).returns("https://github.com/haml/haml/compare/4.0.4...4.0.5")
       cli.expects(:puts).with("https://github.com/haml/haml/compare/4.0.4...4.0.5")
-      cli.outdated
+      cli.each
     end
 
     it "skips outdated gems without responses of y" do
@@ -119,7 +119,7 @@ class CLITest < MiniTest::Spec
       cli.expects(:puts).with("outdated")
       cli.expects(:puts).with("haml: 4.0.5 > 4.0.4")
       outdated_gem.expects(:compare).never
-      cli.outdated
+      cli.each
     end
   end
 


### PR DESCRIPTION
Proposal:

* Make `list` the default command
* Rename `outdated` to `each`