### PR TITLE
Added replacing http to https feature in gemspec's homepage when it's GitHub repository

### DIFF
--- a/lib/gemdiff/repo_finder.rb
+++ b/lib/gemdiff/repo_finder.rb
@@ -92,9 +92,13 @@ module Gemdiff
         end
         return nil unless (yaml = gemspec(gem_name))
         spec = YAML.load(yaml)
-        return spec.homepage if spec.homepage =~ GITHUB_REPO_REGEX
+        return secure_url(spec.homepage) if spec.homepage =~ GITHUB_REPO_REGEX
         match = spec.description.match(GITHUB_REPO_REGEX)
-        match && match[0]
+        match && secure_url(match[0])
+      end
+
+      def secure_url(url)
+        url.gsub(/\Ahttp:/, "https:")
       end
 
       def search(gem_name)

--- a/test/repo_finder_test.rb
+++ b/test/repo_finder_test.rb
@@ -7,7 +7,7 @@ class RepoFinderTest < MiniTest::Spec
     it "returns github url from local gemspec" do
       Gemdiff::RepoFinder.stubs find_local_gemspec: fake_gemspec("homepage: http://github.com/rails/arel")
       Gemdiff::RepoFinder.stubs last_shell_command_success?: true
-      assert_equal "http://github.com/rails/arel", Gemdiff::RepoFinder.github_url("arel")
+      assert_equal "https://github.com/rails/arel", Gemdiff::RepoFinder.github_url("arel")
     end
 
     it "strips anchors from urls" do
@@ -22,7 +22,7 @@ class RepoFinderTest < MiniTest::Spec
       Gemdiff::RepoFinder.stubs find_local_gemspec: ""
       Gemdiff::RepoFinder.stubs last_shell_command_success?: false
       Gemdiff::RepoFinder.stubs find_remote_gemspec: fake_gemspec("homepage: http://github.com/rails/arel")
-      assert_equal "http://github.com/rails/arel", Gemdiff::RepoFinder.github_url("arel")
+      assert_equal "https://github.com/rails/arel", Gemdiff::RepoFinder.github_url("arel")
     end
 
     it "returns github url from github search" do


### PR DESCRIPTION
`gemdiff` makes compare URL from gemspec's homepage like that.
https://github.com/teeparham/gemdiff/compare/v2.0.1...v2.0.2

But many gemspec's homepage starts with http (not https).

Compare URL starts with http doesn't formatted in GitHub like that.
http://github.com/teeparham/gemdiff/compare/v2.0.1...v2.0.2

So, I added feature replacing http to https when it's GitHub repository.