### PR TITLE
Fix an error when gemspec has no description

### DIFF
--- a/lib/gemdiff/repo_finder.rb
+++ b/lib/gemdiff/repo_finder.rb
@@ -101,7 +101,7 @@ module Gemdiff
         return nil unless (yaml = gemspec(gem_name))
         spec = YAML.load(yaml)
         return secure_url(spec.homepage) if spec.homepage =~ GITHUB_REPO_REGEX
-        match = spec.description.match(GITHUB_REPO_REGEX)
+        match = spec.description.match(GITHUB_REPO_REGEX) if spec.description
         match && secure_url(match[0])
       end
 


### PR DESCRIPTION
This PR fixes the following error.

```console
% cat Gemfile
# frozen_string_literal: true

source "https://rubygems.org"

git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }

gem "roda"

% cat Gemfile.lock
GEM
  remote: https://rubygems.org/
  specs:
    rack (2.0.6)
    roda (3.15.0)
      rack

PLATFORMS
  ruby

DEPENDENCIES
  roda

BUNDLED WITH
   2.0.1

% gemdiff
Checking for outdated gems in your bundle...
Fetching gem metadata from https://rubygems.org/...............
Resolving dependencies...

Outdated gems included in the bundle:
  * roda (newest 3.16.0, installed 3.15.0) in groups "default"

roda: 3.16.0 > 3.15.0
Traceback (most recent call last):

(snip)

/Users/koic/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/gemdiff-2.5.0/lib/gemdiff/repo_finder.rb:104:in
`gemspec_homepage': undefined method `match' for nil:NilClass (NoMethodError)
```

This error is caused by roda.gemspec having no `description` attribute.
https://github.com/jeremyevans/roda/blob/3.16.0/roda.gemspec