### PR TITLE
Fix for gemspecs with # character in description

### DIFF
--- a/lib/gemdiff/repo_finder.rb
+++ b/lib/gemdiff/repo_finder.rb
@@ -102,7 +102,7 @@ module Gemdiff
         if (full_name = REPO_EXCEPTIONS[gem_name.to_sym])
           return github_repo(full_name)
         end
-        return nil unless (yaml = gemspec(gem_name))
+        return unless (yaml = gemspec(gem_name))
         spec = YAML.load(yaml)
         return secure_url(spec.homepage) if spec.homepage =~ GITHUB_REPO_REGEX
         match = spec.description.to_s.match(GITHUB_REPO_REGEX)
@@ -116,7 +116,7 @@ module Gemdiff
       def search(gem_name)
         query = "#{gem_name} language:ruby in:name"
         result = octokit_client.search_repositories(query)
-        return nil if result.items.empty?
+        return if result.items.empty?
         github_repo result.items.first.full_name
       end
 

--- a/lib/gemdiff/repo_finder.rb
+++ b/lib/gemdiff/repo_finder.rb
@@ -104,13 +104,14 @@ module Gemdiff
         end
         return unless (yaml = gemspec(gem_name))
         spec = YAML.load(yaml)
-        return secure_url(spec.homepage) if spec.homepage =~ GITHUB_REPO_REGEX
+        return clean_url(spec.homepage) if spec.homepage =~ GITHUB_REPO_REGEX
         match = spec.description.to_s.match(GITHUB_REPO_REGEX)
-        match && secure_url(match[0])
+        match && clean_url(match[0])
       end
 
-      def secure_url(url)
-        url.sub(/\Ahttp:/, "https:")
+      # return https URL with anchors stripped
+      def clean_url(url)
+        url.sub(/\Ahttp:/, "https:").partition("#").first
       end
 
       def search(gem_name)

--- a/lib/gemdiff/repo_finder.rb
+++ b/lib/gemdiff/repo_finder.rb
@@ -133,13 +133,9 @@ module Gemdiff
       end
 
       def gemspec(name)
-        local = find_local_gemspec(name)
-        return find_remote_gemspec(name) unless last_shell_command_success?
-        local.partition("#").first if local =~ GITHUB_REPO_REGEX
-      end
-
-      def last_shell_command_success?
-        $CHILD_STATUS.success?
+        yaml = find_local_gemspec(name)
+        return yaml unless yaml.to_s.empty?
+        find_remote_gemspec(name)
       end
 
       def find_local_gemspec(name)
@@ -147,7 +143,7 @@ module Gemdiff
       end
 
       def find_remote_gemspec(name)
-        `gem spec -r #{name}` if last_shell_command_success?
+        `gem spec -r #{name}`
       end
     end
   end

--- a/test/repo_finder_test.rb
+++ b/test/repo_finder_test.rb
@@ -43,6 +43,12 @@ class RepoFinderTest < MiniTest::Spec
       Gemdiff::RepoFinder.stubs gemspec: NO_DESCRIPTION_GEMSPEC
       assert_nil Gemdiff::RepoFinder.github_url("none")
     end
+
+    it "returns url when # is present in description" do
+      Gemdiff::RepoFinder.stubs find_local_gemspec: ANCHOR_DESCRIPTION_GEMSPEC
+      assert_equal "https://github.com/nicksieger/multipart-post",
+                   Gemdiff::RepoFinder.github_url("multipart-post")
+    end
   end
 
   private
@@ -70,6 +76,18 @@ class RepoFinderTest < MiniTest::Spec
     version: !ruby/object:Gem::Version
       version: 1.2.3
     description:
+  SPEC
+
+  ANCHOR_DESCRIPTION_GEMSPEC = <<~SPEC
+    --- !ruby/object:Gem::Specification
+    name: multipart-post
+    version: !ruby/object:Gem::Version
+      version: 2.0.0
+    description: 'IO values that have #content_type, #original_filename,
+      and #local_path will be posted as a binary file.'
+    homepage: https://github.com/nicksieger/multipart-post
+    licenses:
+    - MIT
   SPEC
 
   def fake_gemspec(extra = "")

--- a/test/repo_finder_test.rb
+++ b/test/repo_finder_test.rb
@@ -6,21 +6,18 @@ class RepoFinderTest < MiniTest::Spec
   describe ".github_url" do
     it "returns github url from local gemspec" do
       Gemdiff::RepoFinder.stubs find_local_gemspec: fake_gemspec("homepage: http://github.com/rails/arel")
-      Gemdiff::RepoFinder.stubs last_shell_command_success?: true
       assert_equal "https://github.com/rails/arel", Gemdiff::RepoFinder.github_url("arel")
     end
 
     it "strips anchors from urls" do
       Gemdiff::RepoFinder.stubs \
         find_local_gemspec: fake_gemspec("homepage: https://github.com/rubysec/bundler-audit#readme")
-      Gemdiff::RepoFinder.stubs last_shell_command_success?: true
       assert_equal "https://github.com/rubysec/bundler-audit",
                    Gemdiff::RepoFinder.github_url("bundler-audit")
     end
 
     it "returns github url from remote gemspec" do
       Gemdiff::RepoFinder.stubs find_local_gemspec: ""
-      Gemdiff::RepoFinder.stubs last_shell_command_success?: false
       Gemdiff::RepoFinder.stubs find_remote_gemspec: fake_gemspec("homepage: http://github.com/rails/arel")
       assert_equal "https://github.com/rails/arel", Gemdiff::RepoFinder.github_url("arel")
     end


### PR DESCRIPTION
Fixes:

```sh
gemdiff find multipart-post

	 4: from /Users/tee/.gem/ruby/2.6.2/gems/gemdiff-2.5.5/lib/gemdiff/repo_finder.rb:106:in `gemspec_homepage'
	 3: from /Users/tee/.rubies/ruby-2.6.2/lib/ruby/2.6.0/psych.rb:277:in `load'
	 2: from /Users/tee/.rubies/ruby-2.6.2/lib/ruby/2.6.0/psych.rb:390:in `parse'
	 1: from /Users/tee/.rubies/ruby-2.6.2/lib/ruby/2.6.0/psych.rb:456:in `parse_stream'
/Users/tee/.rubies/ruby-2.6.2/lib/ruby/2.6.0/psych.rb:456:in `parse': (<unknown>): found unexpected end of stream while scanning a quoted scalar at line 13 column 14 (Psych::SyntaxError)

```