### PR TITLE
Search when gem does not exist

### DIFF
--- a/lib/gemdiff/repo_finder.rb
+++ b/lib/gemdiff/repo_finder.rb
@@ -102,7 +102,8 @@ module Gemdiff
         if (full_name = REPO_EXCEPTIONS[gem_name.to_sym])
           return github_repo(full_name)
         end
-        return unless (yaml = gemspec(gem_name))
+        yaml = gemspec(gem_name)
+        return if yaml.to_s.empty?
         spec = YAML.load(yaml)
         return clean_url(spec.homepage) if spec.homepage =~ GITHUB_REPO_REGEX
         match = spec.description.to_s.match(GITHUB_REPO_REGEX)

--- a/test/repo_finder_test.rb
+++ b/test/repo_finder_test.rb
@@ -22,13 +22,25 @@ class RepoFinderTest < MiniTest::Spec
       assert_equal "https://github.com/rails/arel", Gemdiff::RepoFinder.github_url("arel")
     end
 
-    it "returns github url from github search" do
-      Gemdiff::RepoFinder.stubs octokit_client: mock_octokit("haml/haml")
-      Gemdiff::RepoFinder.stubs gemspec: fake_gemspec
-      assert_equal "https://github.com/haml/haml", Gemdiff::RepoFinder.github_url("haml")
+    it "returns nil when gem does not exist and not found in search" do
+      Gemdiff::RepoFinder.stubs octokit_client: mock_octokit(nil)
+      Gemdiff::RepoFinder.stubs gemspec: ""
+      assert_nil Gemdiff::RepoFinder.github_url("nope")
     end
 
-    it "returns nil when not found" do
+    it "returns url from github search when gem does not exist and found in search" do
+      Gemdiff::RepoFinder.stubs octokit_client: mock_octokit("x/x")
+      Gemdiff::RepoFinder.stubs gemspec: ""
+      assert_equal "https://github.com/x/x", Gemdiff::RepoFinder.github_url("x")
+    end
+
+    it "returns url from github search when not in gemspec" do
+      Gemdiff::RepoFinder.stubs octokit_client: mock_octokit("y/y")
+      Gemdiff::RepoFinder.stubs gemspec: fake_gemspec
+      assert_equal "https://github.com/y/y", Gemdiff::RepoFinder.github_url("y")
+    end
+
+    it "returns nil when not in gemspec and not found" do
       Gemdiff::RepoFinder.stubs octokit_client: mock_octokit(nil)
       Gemdiff::RepoFinder.stubs gemspec: fake_gemspec
       assert_nil Gemdiff::RepoFinder.github_url("not_found")


### PR DESCRIPTION
Follow-up to #19

Fixes:

```sh
$ gemdiff f nope999
Traceback (most recent call last):
	2: from /Users/tee/.gem/ruby/2.6.3/bin/gemdiff:23:in `<main>'
	1: from /Users/tee/.rubies/ruby-2.6.3/lib/ruby/2.6.0/rubygems.rb:302:in `activate_bin_path'
/Users/tee/.rubies/ruby-2.6.3/lib/ruby/2.6.0/rubygems.rb:283:in `find_spec_for_exe': can't find gem gemdiff (>= 0.a) with executable gemdiff (Gem::GemNotFoundException)
```

After fix:
```sh
$ gemdiff f nope999
ERROR:  No gem matching 'nope999 (>= 0)' found
ERROR:  No gem matching 'nope999 (>= 0)' found
Could not find github repository for nope999.
```