### PR TITLE
Remove write accessors

### DIFF
--- a/lib/gemdiff.rb
+++ b/lib/gemdiff.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "English"
 require "gemdiff/version"
 require "gemdiff/colorize"
 require "gemdiff/cli"

--- a/lib/gemdiff/gem_updater.rb
+++ b/lib/gemdiff/gem_updater.rb
@@ -2,7 +2,7 @@
 
 module Gemdiff
   class GemUpdater
-    attr_accessor :name
+    attr_reader :name
 
     def initialize(name)
       @name = name

--- a/lib/gemdiff/outdated_gem.rb
+++ b/lib/gemdiff/outdated_gem.rb
@@ -32,7 +32,7 @@ module Gemdiff
       twilio-ruby
     ].freeze
 
-    attr_accessor :name, :old_version, :new_version
+    attr_reader :name, :old_version, :new_version
 
     def initialize(name, old_version = nil, new_version = nil)
       @name = name


### PR DESCRIPTION
Removed:
```
GemUpdater#name=
OutdatedGem#name=
OutdatedGem#new_version=
OutdatedGem#old_version=
```

Note: Breaking change. Target version 3.0.