### PR TITLE
Add "." as an alias for the current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ to run with the `open` command with a URL argument):
 $ gemdiff open pundit
 ```
 
+You may also use `.` as a shortcut for the current directory name. 
+This is helpful if you would like to quickly open the gem you are developing, for example: 
+
+```sh
+$ pwd
+/Users/you/projects/somegem
+$ gemdiff open .
+```
+
 ### `gemdiff compare [gem] [version] [version]`
 
 Open a compare view for an individual outdated gem in your bundle:
@@ -200,6 +209,19 @@ You can use abbreviations for any of the above commands. For example, this is eq
 ```sh
 $ gemdiff f pundit
 https://github.com/varvet/pundit
+```
+
+All commands that have a gem name argument can now use "." as an alias for the current directory name.
+
+For example:
+
+```sh
+pwd
+/Users/you/ruby/somegem
+gemdiff find .
+gemdiff open .
+gemdiff master .
+gemdiff compare . 1.2.3 master
 ```
 
 ### Authenticated GitHub API requests

--- a/lib/gemdiff/outdated_gem.rb
+++ b/lib/gemdiff/outdated_gem.rb
@@ -35,7 +35,7 @@ module Gemdiff
     attr_reader :name, :old_version, :new_version
 
     def initialize(name, old_version = nil, new_version = nil)
-      @name = name
+      @name = find_name(name)
       set_versions old_version, new_version
     end
 
@@ -96,6 +96,12 @@ module Gemdiff
     end
 
     private
+
+    # When ".", use the name of the current directory
+    def find_name(name)
+      return File.basename(Dir.getwd) if name == "."
+      name
+    end
 
     def clean_url(url)
       uri = URI.parse(url)

--- a/test/outdated_gem_test.rb
+++ b/test/outdated_gem_test.rb
@@ -3,6 +3,16 @@
 require "test_helper"
 
 class OutdatedGemTest < MiniTest::Spec
+  describe "#initialize" do
+    it "sets name" do
+      assert_equal "x", Gemdiff::OutdatedGem.new("x").name
+    end
+
+    it "sets name to current directory when ." do
+      assert_equal "gemdiff", Gemdiff::OutdatedGem.new(".").name
+    end
+  end
+
   describe "#missing_versions?" do
     it "returns true" do
       assert Gemdiff::OutdatedGem.new("x").missing_versions?


### PR DESCRIPTION
All commands that use a gem name can now use "." as an alias for the current directory name.

For example:

```sh
pwd
/Users/you/ruby/somegem
gemdiff find .
gemdiff open .
gemdiff master .
gemdiff compare . 1.2.3 master
```