### PR TITLE
Unlock thor gem in gemspec

### DIFF
--- a/gemdiff.gemspec
+++ b/gemdiff.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "launchy", "~> 2.4"
   spec.add_dependency "octokit", "~> 4.0"
-  spec.add_dependency "thor", "~> 0.19"
+  spec.add_dependency "thor", "~> 1.0"
 
   spec.add_development_dependency "minitest", "~> 5.4"
   spec.add_development_dependency "mocha", "~> 1.1"


### PR DESCRIPTION
Some gems already require `thor` >= 1.0. E.g. [license_finder](https://github.com/pivotal/LicenseFinder/blob/master/license_finder.gemspec#L48)

Relax thor version in gemspec