### PR TITLE
GitHub actions ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    continue-on-error: ${{ matrix.flaky }}
+    strategy:
+      matrix:
+        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1", "jruby-9.2", "jruby-9.3", "truffleruby-21" ,"truffleruby-22"]
+        flaky: [false]
+        include:
+          - ruby-version: "ruby-head"
+            flaky: true
+          - ruby-version: "jruby-head"
+            flaky: true
+          - ruby-version: "truffleruby-head"
+            flaky: true
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Bundle install
+        run: bundle install
+
+      - name: Run Tests
+        run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-cache: bundler
-language: ruby
-rvm:
-  - 3.0
-  - 2.7
-  - 2.6
-  - 2.5

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "pry-byebug" unless ENV["TRAVIS"]
+gem "pry-byebug" unless ENV["CI"]
 
 gemspec

--- a/test/repo_finder_test.rb
+++ b/test/repo_finder_test.rb
@@ -79,6 +79,7 @@ class RepoFinderTest < MiniTest::Spec
     name: fake
     version: !ruby/object:Gem::Version
       version: 1.2.3
+    date: 2021-01-06 00:00:00.000000000 Z
     description: fake
   SPEC
 


### PR DESCRIPTION
Switch to use github actions CI, fix Ruby 3.1 compatibility for tests.

[the successful run](https://github.com/misdoro/gemdiff/actions/runs/2017174193)