### PR TITLE
Require octokit 9, launchy 3

### DIFF
--- a/gemdiff.gemspec
+++ b/gemdiff.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_dependency "launchy", "~> 2.4"
-  spec.add_dependency "octokit", "~> 8.0"
+  spec.add_dependency "octokit", "~> 9.0"
   spec.add_dependency "faraday-retry", "~> 2.2"
   spec.add_dependency "thor", "~> 1.0"
 

--- a/gemdiff.gemspec
+++ b/gemdiff.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.0.0"
 
-  spec.add_dependency "launchy", "~> 2.4"
+  spec.add_dependency "launchy", "~> 3.0"
   spec.add_dependency "octokit", "~> 9.0"
   spec.add_dependency "faraday-retry", "~> 2.2"
   spec.add_dependency "thor", "~> 1.0"


### PR DESCRIPTION
Require the latest major versions of octokit & launchy.

Include in `gemdiff` version 6.